### PR TITLE
Fix for 'wrp_msg' uninitialized build error on yocto environment

### DIFF
--- a/src/libparodus.c
+++ b/src/libparodus.c
@@ -927,7 +927,7 @@ static void *wrp_receiver_thread (void *arg)
 
 int flush_wrp_queue (libpd_mq_t wrp_queue, uint32_t delay_ms)
 {
-	wrp_msg_t *wrp_msg;
+	wrp_msg_t *wrp_msg = NULL;
 	int count = 0;
 	int err, exterr;
 


### PR DESCRIPTION
Fix for below build issue in yocto:

../../RDKB2203/build-arrisxb3/tmp/work/core2-32-rdk-linux/libparodus/git+AUTOINC+21442be9ab-r0/git/src/libparodus.c:941:12: error: 'wrp_msg' may be used uninitialized in this function [-Werror=maybe-uninitialized]
|    wrp_free (wrp_msg);