### PR TITLE
Generic solution for linking lib dir install path based on linux architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,7 @@ set(INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/_install)
 set(PREFIX_DIR ${CMAKE_CURRENT_BINARY_DIR}/_prefix)
 set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
 set(INCLUDE_DIR ${INSTALL_DIR}/include)
-set(NANOMSG_LIBRARY_DIR ${INSTALL_DIR}/lib/x86_64-linux-gnu)
-set(LIBRARY_DIR ${INSTALL_DIR}/lib ${NANOMSG_LIBRARY_DIR})
-set(LIBRARY_DIR64 ${INSTALL_DIR}/lib64)
+set(LIBRARY_DIR ${INSTALL_DIR}/lib ${INSTALL_DIR}/lib/${CMAKE_LIBRARY_ARCHITECTURE})
 set(TEST_RESULTS_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_results)
 file(MAKE_DIRECTORY ${TEST_RESULTS_DIR})
 
@@ -116,7 +114,7 @@ add_dependencies(libwrp-c wrp-c)
 endif ()
 
 add_subdirectory(src)
-link_directories ( ${LIBRARY_DIR} ${LIBRARY_DIR64})
+link_directories ( ${LIBRARY_DIR})
 
 add_definitions(-std=c99)
 


### PR DESCRIPTION
CMAKE_LIBRARY_ARCHITECTURE is used to represent the x86* or i386* lib folder in different linux architecture