### PR TITLE
Remove wdmp-c from target linked libraries, it is not needed. Add dep…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ add_dependencies(libmsgpack msgpack)
 # wrp-c external dependency
 #-------------------------------------------------------------------------------
 ExternalProject_Add(wrp-c
+    DEPENDS trower-base64 msgpack cimplog
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/_prefix/wrp-c
     GIT_REPOSITORY https://github.com/Comcast/wrp-c.git
     GIT_TAG "master"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ set_target_properties(${PROJ_PARODUS_LIB}.shared PROPERTIES OUTPUT_NAME ${PROJ_P
 # Yocto build (ie dynamic lib). Other cases may need fixing too.
 # ----------------------------------------------------------------------------
 if (BUILD_YOCTO)
-target_link_libraries(${PROJ_PARODUS_LIB}.shared m cjson nopoll wrp-c wdmp-c trower-base64 nanomsg msgpackc)
+target_link_libraries(${PROJ_PARODUS_LIB}.shared m cjson nopoll wrp-c trower-base64 nanomsg msgpackc)
 endif (BUILD_YOCTO)
 
 install (TARGETS ${PROJ_PARODUS_LIB} DESTINATION lib${LIB_SUFFIX})


### PR DESCRIPTION
Remove wdmp-c from target linked libraries, it is not needed. Add dependency for msgpack and cimplog to wrp-c so it builds